### PR TITLE
AGL-2845: gewestplan transparant

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ng4-click-outside": "1.0.1",
     "openlayers": "4.6.4",
     "proj4": "2.4.4",
-    "rxjs": "5.5.6",
+    "rxjs": "5.5.8",
     "zone.js": "0.8.18"
   },
   "devDependencies": {

--- a/src/lib/kaart/kaart-elementen.ts
+++ b/src/lib/kaart/kaart-elementen.ts
@@ -34,6 +34,7 @@ export interface WmsLaag {
   readonly versie: Option<string>;
   readonly tileSize: Option<number>;
   readonly format: Option<string>;
+  readonly opacity: Option<number>;
 }
 
 export interface VectorLaag {

--- a/src/lib/kaart/kaart-geoserver-laag.component.ts
+++ b/src/lib/kaart/kaart-geoserver-laag.component.ts
@@ -26,7 +26,8 @@ export class KaartGeoserverLaagComponent extends KaartWmsLaagComponent {
       urls: List(this.config.geoserver.urls),
       versie: fromNullable(this.versie),
       tileSize: fromNullable(this.tileSize),
-      format: fromNullable(this.format)
+      format: fromNullable(this.format),
+      opacity: fromNullable(this.opacity)
     };
   }
 

--- a/src/lib/kaart/kaart-ortho-laag.component.ts
+++ b/src/lib/kaart/kaart-ortho-laag.component.ts
@@ -25,7 +25,8 @@ export class KaartOrthoLaagComponent extends KaartWmsLaagComponent {
       urls: List(this.config.orthofotomozaiek.urls),
       versie: fromNullable(this.versie),
       tileSize: fromNullable(this.tileSize),
-      format: fromNullable(this.format)
+      format: fromNullable(this.format),
+      opacity: fromNullable(this.opacity)
     };
   }
 }

--- a/src/lib/kaart/kaart-tilecache-laag.component.ts
+++ b/src/lib/kaart/kaart-tilecache-laag.component.ts
@@ -25,7 +25,8 @@ export class KaartTilecacheLaagComponent extends KaartWmsLaagComponent {
       urls: List(this.config.tilecache.urls),
       versie: fromNullable(this.versie),
       tileSize: fromNullable(this.tileSize),
-      format: fromNullable(this.format)
+      format: fromNullable(this.format),
+      opacity: fromNullable(this.opacity)
     };
   }
 }

--- a/src/lib/kaart/kaart-wms-laag.component.ts
+++ b/src/lib/kaart/kaart-wms-laag.component.ts
@@ -20,6 +20,7 @@ export class KaartWmsLaagComponent extends KaartLaagComponent implements OnInit 
   @Input() versie?: string;
   @Input() format? = "image/png";
   @Input() tileSize? = 256;
+  @Input() opacity?: number;
   @Input() groep: Laaggroep = "Achtergrond";
 
   constructor(kaart: KaartClassicComponent) {
@@ -41,7 +42,8 @@ export class KaartWmsLaagComponent extends KaartLaagComponent implements OnInit 
       urls: List(this.urls),
       versie: fromNullable(this.versie),
       tileSize: fromNullable(this.tileSize),
-      format: fromNullable(this.format)
+      format: fromNullable(this.format),
+      opacity: fromNullable(this.opacity)
     };
   }
 

--- a/src/lib/kaart/kaart.component.ts
+++ b/src/lib/kaart/kaart.component.ts
@@ -4,7 +4,7 @@ import "rxjs/add/observable/of";
 import "rxjs/add/observable/combineLatest";
 import "rxjs/add/observable/empty";
 import "rxjs/add/observable/never";
-import { scan, map, tap, filter, shareReplay, merge, takeUntil } from "rxjs/operators";
+import { scan, map, tap, filter, shareReplay, merge, takeUntil, share } from "rxjs/operators";
 
 import proj4 from "proj4";
 import * as ol from "openlayers";
@@ -122,7 +122,8 @@ export class KaartComponent extends KaartComponentBase implements OnInit, OnDest
           kaartLogger.debug("produceert", message);
           forEach(message, messageConsumer); // stuur het resultaat terug naar de eigenaar van de kaartcomponent
           return newModel; // en laat het nieuwe model terugvloeien
-        }, initieelModel)
+        }, initieelModel),
+        share()
       );
 
       // subscribe op het model om de zaak aan gang te zwengelen

--- a/src/lib/kaart/laag-converter.ts
+++ b/src/lib/kaart/laag-converter.ts
@@ -11,6 +11,7 @@ export function toOlLayer(kaart: KaartWithInfo, laag: ke.Laag): Option<ol.layer.
       title: l.titel,
       visible: true,
       extent: kaart.config.defaults.extent,
+      opacity: l.opacity.toUndefined(),
       source: new ol.source.TileWMS({
         projection: undefined,
         urls: l.urls.toArray(),
@@ -31,6 +32,7 @@ export function toOlLayer(kaart: KaartWithInfo, laag: ke.Laag): Option<ol.layer.
 
   function createSingleTileWmsLayer(l: ke.WmsLaag) {
     return new ol.layer.Image({
+      opacity: l.opacity.toUndefined(),
       source: new ol.source.ImageWMS({
         url: l.urls.first(),
         params: {


### PR DESCRIPTION
toegevoegd: WMS lagen kunnen een opacity veldje hebben en wanneer dat
er is, wordt het gebruikt om voor transparantie.
aangepast: het model wordt gemulticast via share()
aangepast: RxJs upgrade