### PR TITLE
AGL-2944 styling verbeteringen van kaart interacties onderaan rechts:

### DIFF
--- a/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.html
+++ b/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.html
@@ -1,9 +1,7 @@
-<div class="selector">
-  <div *ngFor="let laag of (backgroundTiles$ | async)">
-    <awv-kaart-achtergrond-tile
-      [laag]="laag"
-      [isCurrent]="isCurrentlyBackground(laag)"
-      [@visibility]="tileVisibility(laag)"
-      (click)=kies(laag)></awv-kaart-achtergrond-tile>
-  </div>
+<div class="achtergrond-selector">
+  <awv-kaart-achtergrond-tile *ngFor="let laag of (backgroundTiles$ | async)"
+                              [laag]="laag"
+                              [isCurrent]="isCurrentlyBackground(laag)"
+                              [@visibility]="tileVisibility(laag)"
+                              (click)=kies(laag)></awv-kaart-achtergrond-tile>
 </div>

--- a/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.scss
+++ b/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.scss
@@ -1,11 +1,7 @@
-.selector {
+.achtergrond-selector {
   display: flex;
-  flex-direction: row;
-  position: absolute;
-  bottom: 26px; // 26 omdat er geen shadow van -3px rond zit, 1px voor border
-  right: 48px;
-}
 
-.selector div {
-  display: initial; // de parent is flex, maar we willen terug naar block
+  > * {
+    margin-right: 8px;
+  }
 }

--- a/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.ts
+++ b/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.ts
@@ -29,8 +29,7 @@ const Invisible = "invisible";
         Visible,
         style({
           opacity: "1.0",
-          maxWidth: "100px",
-          marginRight: "12px"
+          maxWidth: "80px"
         })
       ),
       state(

--- a/src/lib/kaart/achtergrond-selector/kaart-achtergrond-tile.component.html
+++ b/src/lib/kaart/achtergrond-selector/kaart-achtergrond-tile.component.html
@@ -1,3 +1,3 @@
 <div class="kaart-widget achtergrond-tile" [style.background-image]="'url('+background()+')'">
-  <div class="title" [class.current]="isCurrent">{{laag.titel}}</div>
+  <div class="title">{{laag.titel}}</div>
 </div>

--- a/src/lib/kaart/achtergrond-selector/kaart-achtergrond-tile.component.html
+++ b/src/lib/kaart/achtergrond-selector/kaart-achtergrond-tile.component.html
@@ -1,3 +1,3 @@
-<div class="kaart-widget minimap" [style.background-image]="'url('+background()+')'">
+<div class="kaart-widget achtergrond-tile" [style.background-image]="'url('+background()+')'">
   <div class="title" [class.current]="isCurrent">{{laag.titel}}</div>
 </div>

--- a/src/lib/kaart/achtergrond-selector/kaart-achtergrond-tile.component.scss
+++ b/src/lib/kaart/achtergrond-selector/kaart-achtergrond-tile.component.scss
@@ -1,48 +1,32 @@
 @import "../../css/kaart.component-common.scss";
 
-$map-border-color: #aa8;
-$map-background-color: whitesmoke;
-// We zouden dit moeten van de AWV theme halen
-$map-title-main-color: #dd7921;
-$tile-size: 100px;
-$tile-width: $tile-size;
-$tile-height: $tile-size;
-$title-height: 20px;
-$title-font-size: 12px;
+$tile-size: 76px;
 
-.minimap {
-  border: 1px solid $map-border-color;
-  background-color: $map-background-color;
-  width: $tile-width; // zo groot willen we zijn
-  height: $tile-height;
+.achtergrond-tile {
+  background-color: whitesmoke;
+  width: $tile-size; // zo groot willen we zijn
+  height: $tile-size;
   max-height: inherit; // We willen dat we passen in de parent
   max-width: inherit;
   overflow: hidden;
   cursor: pointer; // Toon de gebruiker dat er geklikt kan worden
-  display: inline-block; // De parent had dit anders gezet
-  box-sizing: border-box;
+  border: 2px solid white;
+  border-radius: 2px;
+  margin-right: 8px;
+  display: flex;
+  align-items: flex-end;
 }
 
 .title {
-  width: $tile-width;
-  max-width: $tile-width;
-  height: $title-height;
   overflow: hidden;
-  text-align: center;
-  color: $map-title-main-color;
-  background-color: $map-background-color;
-  font-style: normal;
-  font-variant-ligatures: normal;
-  font-variant-caps: normal;
-  font-variant-numeric: normal;
-  font-variant-east-asian: normal;
-  font-weight: 500;
-  font-stretch: normal;
-  font-size: $title-font-size;
-  line-height: $title-height;
+  color: white;
+  font-size: 12px;
+  padding: 24px 4px 4px 4px;
+  text-shadow: rgba(0,0,0,0.7) 0px 1px 8px;
+  background-image: linear-gradient(transparent,rgba(0,0,0,0.37));
+  width: 100%;
 }
 
 .current {
-  color: $map-background-color; // inverteer de kleuren van de titelblak
-  background-color: $map-title-main-color;
+  color: white;
 }

--- a/src/lib/kaart/achtergrond-selector/kaart-achtergrond-tile.component.scss
+++ b/src/lib/kaart/achtergrond-selector/kaart-achtergrond-tile.component.scss
@@ -26,7 +26,3 @@ $tile-size: 76px;
   background-image: linear-gradient(transparent,rgba(0,0,0,0.37));
   width: 100%;
 }
-
-.current {
-  color: white;
-}

--- a/src/lib/kaart/achtergrond-selector/kaart-achtergrond-tile.component.scss
+++ b/src/lib/kaart/achtergrond-selector/kaart-achtergrond-tile.component.scss
@@ -19,6 +19,7 @@ $tile-size: 76px;
 
 .title {
   overflow: hidden;
+  user-select: none;
   color: white;
   font-size: 12px;
   padding: 24px 4px 4px 4px;

--- a/src/lib/kaart/kaart.component.html
+++ b/src/lib/kaart/kaart.component.html
@@ -3,10 +3,6 @@
     <div class="kaart" #map style="height: 100%; width: 100%;"></div>
   </div>
   <div id="overlay" *ngIf="aanwezigeElementen$ | async as aanwezigeElementen">
-    <awv-kaart-open-street-view></awv-kaart-open-street-view>
-    <awv-kaart-achtergrond-selector *ngIf="aanwezigeElementen.contains('Achtergrondkeuze')"></awv-kaart-achtergrond-selector>
-    <awv-kaart-mijn-locatie></awv-kaart-mijn-locatie>
-    <awv-kaart-zoom></awv-kaart-zoom>
     <awv-google-wdb-locatie-zoeker></awv-google-wdb-locatie-zoeker>
     <awv-crab-zoeker></awv-crab-zoeker>
     <div class="kaart-links">
@@ -16,10 +12,20 @@
       <ng-content select=".kaart-links"></ng-content>
     </div>
     <awv-kaart-teken-laag *ngIf="aanwezigeElementen.contains('Kaarttekenen')"></awv-kaart-teken-laag>
-    <div class="kaart-info-box">
-      <awv-copyright *ngIf="aanwezigeElementen.contains('Copyright')"></awv-copyright>
-      <awv-voorwaarden *ngIf="aanwezigeElementen.contains('Voorwaarden')"></awv-voorwaarden>
-      <awv-schaal *ngIf="aanwezigeElementen.contains('Schaal')"></awv-schaal>
+    <div class="kaart-rechts-onderaan">
+      <div class="kaart-interacties">
+        <awv-kaart-achtergrond-selector class="kaart-achtergrond-selector" *ngIf="aanwezigeElementen.contains('Achtergrondkeuze')"></awv-kaart-achtergrond-selector>
+        <div class="kaart-controls">
+          <awv-kaart-open-street-view></awv-kaart-open-street-view>
+          <awv-kaart-mijn-locatie></awv-kaart-mijn-locatie>
+          <awv-kaart-zoom></awv-kaart-zoom>
+        </div>
+      </div>
+      <div class="kaart-footer-info">
+        <awv-copyright *ngIf="aanwezigeElementen.contains('Copyright')"></awv-copyright>
+        <awv-voorwaarden *ngIf="aanwezigeElementen.contains('Voorwaarden')"></awv-voorwaarden>
+        <awv-schaal *ngIf="aanwezigeElementen.contains('Schaal')"></awv-schaal>
+      </div>
     </div>
   </div>
 </div>

--- a/src/lib/kaart/kaart.component.scss
+++ b/src/lib/kaart/kaart.component.scss
@@ -95,15 +95,37 @@ awv-kaart-info-boodschappen {
   background-color: #555;
 }
 
-.kaart-info-box {
+.kaart-rechts-onderaan {
   display: flex;
-  flex-direction: row;
-  background-color:rgba(255, 255, 255, 0.75);
+  flex-direction: column;
   position: absolute;
-  bottom: 0px;
-  right: 0px;
-  height: 16px;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  box-sizing: border-box;
+  bottom: 0;
+  right: 0;
+
+  .kaart-interacties {
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+  }
+
+  .kaart-achtergrond-selector {
+    margin-bottom: 8px;
+  }
+
+  .kaart-controls {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    margin: 0 8px 8px 0;
+  }
+
+  .kaart-footer-info {
+    display: flex;
+    align-items: center;
+    font-size: 10px;
+    color: black;
+    background-color: rgba(white, 0.87);
+    padding: 0;
+    border-radius: 4px 0 0 0;
+  }
 }

--- a/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.html
+++ b/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.html
@@ -1,7 +1,5 @@
-<div *ngIf="enabled$ | async">
-  <div class="kaart-widget actions panel">
-    <button #locateBtn mat-raised-button>
-      <mat-icon aria-label="mijn locatie">my_location</mat-icon>
-    </button>
-  </div>
+<div *ngIf="enabled$ | async" class="kaart-widget mijn-locatie">
+  <button #locateBtn mat-icon-button>
+    <mat-icon aria-label="mijn locatie">my_location</mat-icon>
+  </button>
 </div>

--- a/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.scss
+++ b/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.scss
@@ -1,22 +1,12 @@
 @import "../../css/kaart.component-common.scss";
 
-.panel {
-  min-width: 24px;
-}
+.mijn-locatie {
+  width: 32px;
+  margin-top: 8px;
 
-.actions {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: space-around;
-  position: absolute;
-  right: 16px;
-  bottom: 110px;
-}
-
-.actions > .mat-raised-button {
-  min-width: 24px;
-  padding-left: 0;
-  padding-right: 0;
-  line-height: 24px;
+  > * {
+    width: 32px;
+    height: 32px;
+    line-height: 32px;
+  }
 }

--- a/src/lib/kaart/open-street-view/kaart-open-street-view.component.html
+++ b/src/lib/kaart/open-street-view/kaart-open-street-view.component.html
@@ -1,5 +1,5 @@
-<div class="kaart-widget actions panel">
-  <button mat-raised-button (click)="toggleLuisterenOpKaartClicks()">
+<div class="kaart-widget open-street-view">
+  <button mat-icon-button (click)="toggleLuisterenOpKaartClicks()">
     <mat-icon [class.actief]="isActief" aria-label="open google street view">streetview</mat-icon>
   </button>
 </div>

--- a/src/lib/kaart/open-street-view/kaart-open-street-view.component.scss
+++ b/src/lib/kaart/open-street-view/kaart-open-street-view.component.scss
@@ -1,26 +1,16 @@
 @import "../../css/kaart.component-common";
 
-.panel {
-  min-width: 24px;
-}
+.open-street-view {
+  width: 32px;
+  margin-top: 8px;
 
-.actions {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: space-around;
-  position: absolute;
-  right: 16px;
-  bottom: 84px;
-}
+  > * {
+    width: 32px;
+    height: 32px;
+    line-height: 32px;
+  }
 
-.actions > .mat-raised-button {
-  min-width: 24px;
-  padding-left: 0;
-  padding-right: 0;
-  line-height: 24px;
-}
-
-.actief {
-  color: darkred;
+  .actief {
+    color: $awv-primary-3;
+  }
 }

--- a/src/lib/kaart/schaal/kaart-schaal.scss
+++ b/src/lib/kaart/schaal/kaart-schaal.scss
@@ -1,5 +1,7 @@
 :host ::ng-deep .awv-schaal {
-  width: 104px; // Dit is de kleinste breedte (in veelvouden van 8px) waar de schaal altijd in past
+  //INFO: vaste breedte lijkt mij overbodig, verspringing is minimaal en is minder storend dat de wit-ruimte (google-maps heeft ook verspringing)
+  //width: 104px; // Dit is de kleinste breedte (in veelvouden van 8px) waar de schaal altijd in past
+  margin: 0 8px 0 4px;
 }
 
 :host ::ng-deep .awv-schaal-inner {
@@ -10,5 +12,5 @@
   font-size: 10px;
   text-align: center;
   margin: 1px auto;
-  will-change: contents,width;
+  will-change: contents, width;
 }

--- a/src/lib/kaart/zoom/kaart-zoom.component.html
+++ b/src/lib/kaart/zoom/kaart-zoom.component.html
@@ -1,9 +1,11 @@
-<div *ngIf="kaartProps$ | async as props">
-  <div class="kaart-widget actions panel">
-    <button mat-raised-button (click)="zoomIn(props)" [disabled]="!props.canZoomIn">
+<div *ngIf="kaartProps$ | async as props" class="kaart-widget zoom-knoppen">
+  <div class="zoom-knop">
+    <button mat-icon-button (click)="zoomIn(props)" [disabled]="!props.canZoomIn">
       <mat-icon aria-label="zoom in">add</mat-icon>
     </button>
-    <button mat-raised-button (click)="zoomOut(props)" [disabled]="!props.canZoomOut">
+  </div>
+  <div class="zoom-knop">
+    <button mat-icon-button (click)="zoomOut(props)" [disabled]="!props.canZoomOut">
       <mat-icon aria-label="zoom out">remove</mat-icon>
     </button>
   </div>

--- a/src/lib/kaart/zoom/kaart-zoom.component.scss
+++ b/src/lib/kaart/zoom/kaart-zoom.component.scss
@@ -1,23 +1,20 @@
 @import "../../css/kaart.component-common.scss";
 
-.panel {
-  min-width: 24px;
-}
-
-.actions {
+.zoom-knoppen {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
-  position: absolute;
-  right: 16px;
-  bottom: 30px;
- }
-
-.actions > .mat-raised-button {
-  min-width: 24px;
-  padding-left: 0;
-  padding-right: 0;
-  line-height: 24px;
+  width: 32px;
+  margin-top: 8px;
 }
 
+.zoom-knop > * {
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+}
+
+.zoom-knop + .zoom-knop {
+  border-top: 1px solid #EAEAEA;
+}

--- a/src/lib/lagenkiezer/laagmanipulatie.component.scss
+++ b/src/lib/lagenkiezer/laagmanipulatie.component.scss
@@ -33,5 +33,4 @@
 
 .laag-acties {
   width: 40px;
-  padding-right: 8px;
 }

--- a/src/lib/lagenkiezer/lagenkiezer.component.scss
+++ b/src/lib/lagenkiezer/lagenkiezer.component.scss
@@ -68,14 +68,20 @@ $laag-height: 40px;
   );
 }
 
-.no-drag ::before {
-  font-family: "Material Icons";
-  content: '\e14b';
-  @include mat-icon-size(24px);
-  position: absolute;
-  right: 24px;
-  margin-top: 8px;
-  color: $kaart-warn-color;
+.no-drag {
+  ::ng-deep .laag .laag-acties {
+    display: none;
+  }
+
+  ::before {
+    font-family: "Material Icons";
+    content: '\e14b';
+    @include mat-icon-size(24px);
+    position: absolute;
+    right: 24px;
+    margin-top: 8px;
+    color: $kaart-warn-color;
+  }
 }
 
 // Volgende css-classes worden momenteel nog niet gebruikt - en dus voorlopig in commentaar gezet

--- a/src/lib/zoeker/box/zoeker-box.html
+++ b/src/lib/zoeker/box/zoeker-box.html
@@ -1,7 +1,7 @@
 <div class="kaart-widget">
   <div class="zoeker-input">
 
-    <mat-menu #zoekerMenu="matMenu" class="zoeker-menu">
+    <mat-menu #zoekerMenu="matMenu" class="zoeker-menu" [overlapTrigger]="false">
       <button mat-menu-item (click)="kiesZoeker('Geoloket')" [disabled]="actieveZoeker === 'Geoloket'">
         <mat-icon>search</mat-icon>
         <span>Zoek in geoloket</span>

--- a/src/testApp/app.component.html
+++ b/src/testApp/app.component.html
@@ -1,6 +1,4 @@
-<h1>AWV Commons</h1>
-
-<h2>Kaart</h2>
+<h1>ng-kaart: testpagina met aantal config voorbeelden</h1>
 <div class="protractor">
   <h3>Kaart voor protractor</h3>
   <button (click)="maakZichtbaar('orthomap', !isZichtbaar('orthomap'))">{{isZichtbaar('orthomap')?'Verberg':'Toon'}}
@@ -65,7 +63,7 @@
   </button>
   <awv-kaart-classic *ngIf="isZichtbaar('dynamischefeatures')" [breedte]="1200" [hoogte]="600" [zoom]="6"
                      [middelpunt]="installatieCoordinaat"
-                     >
+  >
     <awv-kaart-tilecache-laag [titel]="'Dienstkaart grijs'" [laagNaam]="'dienstkaart-grijs'"></awv-kaart-tilecache-laag>
     <awv-kaart-features-laag [features]="installaties" [titel]="'features'" [minZoom]="2"></awv-kaart-features-laag>
     <!--[selecteerbaar]="true"
@@ -184,7 +182,7 @@
     <awv-kaart-standaard-interacties></awv-kaart-standaard-interacties>
     <awv-kaart-nosqlfs-laag [titel]="'Fietspaden'" [url]="'https://apps-dev.mow.vlaanderen.be/geolatte-nosqlfs'"
                             [database]="'featureserver'" [collection]="'fietspaden'"
-                            [styleFunction]="fietspadStyleMetOffset"  [selectieStyle]="fietspadSelectieStyleMetOffset"
+                            [styleFunction]="fietspadStyleMetOffset" [selectieStyle]="fietspadSelectieStyleMetOffset"
                             [minZoom]="7"></awv-kaart-nosqlfs-laag>
   </awv-kaart-classic>
 </div>
@@ -212,7 +210,7 @@
   <awv-kaart-classic *ngIf="isZichtbaar('metenVoorbeeld')" [naam]="'metenVoorbeeld'">
     <awv-kaart-ortho-laag [titel]="'Ortho'"></awv-kaart-ortho-laag>
     <awv-kaart-standaard-interacties></awv-kaart-standaard-interacties>
-    <awv-kaart-teken [geometryType]="'Polygon'" [tekenen]="isTekenenActief()"  (getekendeGeom)="geomGetekend($event)"></awv-kaart-teken>
+    <awv-kaart-teken [geometryType]="'Polygon'" [tekenen]="isTekenenActief()" (getekendeGeom)="geomGetekend($event)"></awv-kaart-teken>
     <awv-kaart-schaal></awv-kaart-schaal>
     <awv-kaart-copyright></awv-kaart-copyright>
     <awv-kaart-voorwaarden></awv-kaart-voorwaarden>
@@ -244,16 +242,25 @@
   </awv-kaart-classic>
 </div>
 
-<h3>Kaart met copyright, voorwaarden en schaal</h3>
-<div>
-  <button (click)="maakZichtbaar('voorwaarden', !isZichtbaar('voorwaarden'))">
-    {{isZichtbaar('voorwaarden')?'Verberg':'Toon'}}
-  </button>
-  <awv-kaart-classic *ngIf="isZichtbaar('voorwaarden')" [naam]="'voorwaarden'">
-      <awv-kaart-tilecache-laag [titel]="'Dienstkaart grijs'" [laagNaam]="'dienstkaart-grijs'"></awv-kaart-tilecache-laag>
-      <awv-kaart-copyright [copyright]="'&copy; Dit is van ons'"></awv-kaart-copyright>
-      <awv-kaart-voorwaarden *ngIf="!!voorwaarden" [titel]="voorwaarden"></awv-kaart-voorwaarden>
-      <awv-kaart-schaal></awv-kaart-schaal>
+<h3>Kaart voor het testen van de interacties - met mogelijkheid om bepaalde features aan/uit te zetten of te veranderen</h3>
+<div style="margin-bottom: 40px;">
+  <div>
+    <div style="padding: 8px;">
+      <button mat-raised-button (click)="toggleInteractieZichtbaar(key)" *ngFor="let key of objectKeys(interacties)">Zet <strong>{{key}}</strong> {{isInteractieZichtbaar(key.toString()) ? "UIT" : "AAN"}}</button>
+    </div>
+    <div style="padding: 8px;">
+      <button (click)="maakZichtbaar('interacties', !isZichtbaar('interacties'))">{{isZichtbaar('interacties')?'Verberg kaart':'Toon kaart'}}</button>
+      <button (click)="veranderVoorwaarden()">Andere voorwaarden</button>
+    </div>
+  </div>
+  <awv-kaart-classic *ngIf="isZichtbaar('interacties')" [naam]="'interacties'" [mijnLocatieZoom]="getMijnLocatieZoom()">
+    <awv-kaart-tilecache-laag [titel]="'Dienstkaart grijs'" [laagNaam]="'dienstkaart-grijs'"></awv-kaart-tilecache-laag>
+    <awv-kaart-tilecache-laag [titel]="'Dienstkaart kleur'" [laagNaam]="'dienstkaart-kleur'" *ngIf="isInteractieZichtbaar('achtergrond')"></awv-kaart-tilecache-laag>
+    <awv-kaart-blanco-laag [titel]="'Leeg'" *ngIf="isInteractieZichtbaar('achtergrond')"></awv-kaart-blanco-laag>
+    <awv-kaart-knop-achtergrondlaag-kiezer [titels]="['Dienstkaart grijs', 'Dienstkaart kleur', 'Leeg']" *ngIf="isInteractieZichtbaar('achtergrond')"></awv-kaart-knop-achtergrondlaag-kiezer>
+    <awv-kaart-standaard-interacties [focusVoorZoom]="true" *ngIf="isInteractieZichtbaar('mijnlocatie')"></awv-kaart-standaard-interacties>
+    <awv-kaart-copyright *ngIf="isInteractieZichtbaar('copyright')"></awv-kaart-copyright>
+    <awv-kaart-voorwaarden *ngIf="isInteractieZichtbaar('voorwaarden')" [titel]="voorwaarden"></awv-kaart-voorwaarden>
+    <awv-kaart-schaal *ngIf="isInteractieZichtbaar('schaal')"></awv-kaart-schaal>
   </awv-kaart-classic>
-  <button *ngIf="isZichtbaar('voorwaarden')" (click)="veranderVoorwaarden()">Andere voorwaarden</button>
 </div>

--- a/src/testApp/app.component.html
+++ b/src/testApp/app.component.html
@@ -244,12 +244,12 @@
 
 <h3>Kaart voor het testen van de interacties - met mogelijkheid om bepaalde features aan/uit te zetten of te veranderen</h3>
 <div style="margin-bottom: 40px;">
-  <div>
+  <button style="margin: 0 8px 8px 8px;" (click)="maakZichtbaar('interacties', !isZichtbaar('interacties'))">{{isZichtbaar('interacties')?'Verberg kaart':'Toon kaart'}}</button>
+  <div *ngIf="isZichtbaar('interacties')">
     <div style="padding: 8px;">
-      <button mat-raised-button (click)="toggleInteractieZichtbaar(key)" *ngFor="let key of objectKeys(interacties)">Zet <strong>{{key}}</strong> {{isInteractieZichtbaar(key.toString()) ? "UIT" : "AAN"}}</button>
+      <button (click)="toggleInteractieZichtbaar(key)" *ngFor="let key of objectKeys(interacties)">Zet <strong>{{key}}</strong> {{isInteractieZichtbaar(key.toString()) ? "UIT" : "AAN"}}</button>
     </div>
     <div style="padding: 8px;">
-      <button (click)="maakZichtbaar('interacties', !isZichtbaar('interacties'))">{{isZichtbaar('interacties')?'Verberg kaart':'Toon kaart'}}</button>
       <button (click)="veranderVoorwaarden()">Andere voorwaarden</button>
     </div>
   </div>

--- a/src/testApp/app.component.ts
+++ b/src/testApp/app.component.ts
@@ -29,7 +29,7 @@ export class AppComponent {
   private readonly zichtbaarheid = {
     orthomap: false,
     lagenkiezer: true,
-    voorwaarden: true
+    interacties: true
   };
 
   private readonly fietspadStijlDef: AWV0StyleFunctionDescription = {
@@ -143,6 +143,15 @@ export class AppComponent {
   private alleVoorwaarden = ["Er zijn nieuwe voorwaarden", "Er zijn nog nieuwere voorwaarden", undefined];
   voorwaarden = this.alleVoorwaarden[0];
   private voorwaardenIndex = 0;
+
+  objectKeys = Object.keys;
+  interacties = {
+    achtergrond: true,
+    mijnlocatie: true,
+    schaal: true,
+    voorwaarden: true,
+    copyright: true
+  };
 
   // Dit werkt alleen als apigateway bereikbaar is. Zie CORS waarschuwing in README.
   readonly districtSource: ol.source.Vector = new ol.source.Vector({
@@ -281,6 +290,22 @@ export class AppComponent {
   veranderVoorwaarden() {
     this.voorwaardenIndex = (this.voorwaardenIndex + 1) % this.alleVoorwaarden.length;
     this.voorwaarden = this.alleVoorwaarden[this.voorwaardenIndex];
+  }
+
+  isInteractieZichtbaar(interactie: string): boolean {
+    return this.interacties[interactie];
+  }
+
+  toggleInteractieZichtbaar(interactie: string) {
+    this.interacties[interactie] = !this.interacties[interactie];
+  }
+
+  getMijnLocatieZoom(): string {
+    if (this.interacties["mijnlocatie"]) {
+      return "8";
+    } else {
+      return null;
+    }
   }
 
   verplaatsLagen() {


### PR DESCRIPTION
- volledig met flexbox en niet meer met 'position: absolute' om zo beter om te gaan met widgets die wel of niet getoond moeten worden
- knoppen wat groter gemaakt zodat ze gemakkelijker gebruikt kunnen worden
- ruimte tussen de verschillende widgets en de rand van de kaart steeds 8px
- test-app aangepast zodat de verschillende mogelijkheden snel kunnen getest worden

[https://www.dropbox.com/s/gcnfz1jajb81fp7/Screenshot%202018-05-30%2012.21.08.png?dl=0](url)