### PR TITLE
AGL-2910 linkerpaneel kunnen dichtklappen

### DIFF
--- a/src/lib/classic/kaart-classic.component.html
+++ b/src/lib/classic/kaart-classic.component.html
@@ -7,6 +7,9 @@
   [messageObsConsumer]='kaartMsgObservableConsumer'
   (click)="focus()"
   (clickOutside)="geenFocus()">
+  <ng-container class="kaart-fixed-links-boven">
+    <ng-content select=".kaart-fixed-links-boven"></ng-content>
+  </ng-container>
   <ng-container class="kaart-links">
     <ng-content select=".kaart-links"></ng-content>
   </ng-container>

--- a/src/lib/kaart/kaart.component.html
+++ b/src/lib/kaart/kaart.component.html
@@ -2,10 +2,19 @@
   <div id="kaart-container">
     <div class="kaart" #map style="height: 100%; width: 100%;"></div>
   </div>
-  <div id="overlay" *ngIf="aanwezigeElementen$ | async as aanwezigeElementen">
+  <div id="overlay" *ngIf="aanwezigeElementen$ | async as aanwezigeElementen"
+       [ngClass]="{ 'kaart-links-zichtbaar': kaartLinksZichtbaar, 'kaart-links-niet-zichtbaar': !kaartLinksZichtbaar,
+                    'kaart-links-scrollbar-zichtbaar': kaartLinksScrollbarZichtbaar, 'kaart-links-scrollbar-niet-zichtbaar': !kaartLinksScrollbarZichtbaar }">
     <awv-google-wdb-locatie-zoeker></awv-google-wdb-locatie-zoeker>
     <awv-crab-zoeker></awv-crab-zoeker>
-    <div class="kaart-links">
+    <button mat-icon-button class="kaart-links-zichtbaar-toggle-knop" (click)="toggleKaartLinks()" *ngIf="kaartLinksToggleZichtbaar">
+      <mat-icon *ngIf="kaartLinksZichtbaar">chevron_left</mat-icon>
+      <mat-icon *ngIf="!kaartLinksZichtbaar">chevron_right</mat-icon>
+    </button>
+    <div #kaartFixedLinksBoven class="kaart-fixed-links-boven">
+      <ng-content select=".kaart-fixed-links-boven"></ng-content>
+    </div>
+    <div #kaartLinks class="kaart-links">
       <awv-zoeker *ngIf="aanwezigeElementen.contains('Zoeker')"></awv-zoeker>
       <awv-lagenkiezer *ngIf="aanwezigeElementen.contains('Lagenkiezer')"></awv-lagenkiezer>
       <awv-kaart-info-boodschappen></awv-kaart-info-boodschappen>

--- a/src/lib/kaart/kaart.component.scss
+++ b/src/lib/kaart/kaart.component.scss
@@ -1,3 +1,5 @@
+$kaart-links-breedte: 480px;
+
 .fullscreen-container {
 
   &:-moz-full-screen {
@@ -46,13 +48,59 @@
   top: 0px;
   left: 0px;
   pointer-events: none;
+  overflow: hidden;
+
+  &.kaart-links-zichtbaar {
+    .kaart-links, .kaart-fixed-links-boven {
+      left: 0;
+    }
+    .kaart-links-zichtbaar-toggle-knop {
+      left: $kaart-links-breedte - 8px;
+    }
+
+    &.kaart-links-scrollbar-zichtbaar {
+      .kaart-links {
+        background: #fafafa;
+        box-shadow: 0 0 20px rgba(0, 0, 0, 0.3);
+      }
+      .kaart-fixed-links-boven {
+        background: #fafafa;
+        box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
+      }
+      .kaart-links-zichtbaar-toggle-knop {
+        left: $kaart-links-breedte;
+      }
+    }
+  }
+
+  &.kaart-links-niet-zichtbaar {
+    .kaart-links, .kaart-fixed-links-boven {
+      left: -$kaart-links-breedte;
+    }
+
+    .kaart-links-zichtbaar-toggle-knop {
+      left: 0;
+    }
+  }
+}
+
+.kaart-fixed-links-boven {
+  pointer-events: initial;
+  width: $kaart-links-breedte;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 3;
+  transition: left 0.3s cubic-bezier(.25, .8, .25, 1);
 }
 
 .kaart-links {
+  z-index: 2;
   position: absolute;
-  max-height: 100%;
+  padding-top: 8px;
+  max-height: calc(100% - 8px); // -8px van padding-top
   height: auto;
-  width: 480px;
+  width: $kaart-links-breedte;
   top: 0;
   left: 0;
   display: flex;
@@ -60,7 +108,32 @@
   overflow-x: hidden;
   overflow-y: auto;
   pointer-events: initial;
-  margin: 8px 0 0 0;
+  transition: left 0.3s cubic-bezier(.25, .8, .25, 1);
+}
+
+.kaart-links-zichtbaar-toggle-knop {
+  z-index: 1;
+  position: absolute;
+  top: 12px;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+  border: none;
+  border-radius: 0 2px 2px 0;
+  box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.3);
+  background: #fafafa;
+  pointer-events: initial;
+  color: #777;
+
+  &:hover {
+    color: #333;
+  }
+
+  /deep/ .mat-button-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 }
 
 awv-zoeker {

--- a/src/testApp/app.component.html
+++ b/src/testApp/app.component.html
@@ -253,7 +253,7 @@
     <button (click)="veranderVoorwaarden()">Andere voorwaarden</button>
   </div>
 </div>
-<div style="margin: 8px;border: 1px solid rgba(0,0,0,0.87);" *ngIf="isZichtbaar('interacties')">
+<div style="margin: 24px; border-radius: 2px;border: 1px solid rgba(0,0,0,0.26);box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);" *ngIf="isZichtbaar('interacties')">
   <awv-kaart-classic [naam]="'interacties'" [mijnLocatieZoom]="getMijnLocatieZoom()" (zoomChange)="onZoom($event)" (middelpuntChange)="onMiddelpunt($event)" (extentChange)="onExtent($event)">
     <awv-kaart-tilecache-laag [titel]="'Dienstkaart grijs'" [laagNaam]="'dienstkaart-grijs'"></awv-kaart-tilecache-laag>
     <awv-kaart-tilecache-laag [titel]="'Dienstkaart kleur'" [laagNaam]="'dienstkaart-kleur'" *ngIf="isInteractieZichtbaar('achtergrond')"></awv-kaart-tilecache-laag>
@@ -270,6 +270,11 @@
     <awv-kaart-copyright *ngIf="isInteractieZichtbaar('copyright')"></awv-kaart-copyright>
     <awv-kaart-voorwaarden *ngIf="isInteractieZichtbaar('voorwaarden')" [titel]="voorwaarden"></awv-kaart-voorwaarden>
     <awv-kaart-schaal *ngIf="isInteractieZichtbaar('schaal')"></awv-kaart-schaal>
+    <div class="kaart-fixed-links-boven" *ngIf="isInteractieZichtbaar('fixedHeaderLinksBoven')">
+      <div class="custom-kaart-fixed-links-boven">
+        <span class="custom-titel">kaart-fixed-links-boven content voorbeeld</span>
+      </div>
+    </div>
   </awv-kaart-classic>
 </div>
 

--- a/src/testApp/app.component.scss
+++ b/src/testApp/app.component.scss
@@ -15,3 +15,28 @@ body {
 .onder {
   order: 120;
 }
+
+.kaart-links-scrollbar-zichtbaar {
+  .kaart-fixed-links-boven {
+    background: orange !important;
+
+    .custom-kaart-fixed-links-boven {
+      margin: 8px;
+    }
+  }
+}
+
+.custom-kaart-fixed-links-boven {
+  margin: 8px 8px 0 8px;
+
+  .custom-titel {
+    background: white;
+    border-radius: 2px;
+    padding: 0 16px;
+    color: rgba(black, 0.6);
+    height: 40px;
+    display: flex;
+    align-items: center;
+    box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  }
+}

--- a/src/testApp/app.component.ts
+++ b/src/testApp/app.component.ts
@@ -32,8 +32,9 @@ export class AppComponent {
   @ViewChild("selectie") private selectieKaart: KaartClassicComponent;
 
   private readonly zichtbaarheid = {
+    interacties: true,
     orthomap: false,
-    featuresApi: true
+    featuresApi: false
   };
 
   private readonly fietspadStijlDef: AWV0StyleFunctionDescription = {
@@ -153,6 +154,7 @@ export class AppComponent {
 
   objectKeys = Object.keys;
   interacties = {
+    fixedHeaderLinksBoven: true,
     zoeker: true,
     lagenkiezer: true,
     standaardinteracties: true,


### PR DESCRIPTION
- mogelijkheid om linkerpaneel dicht te klappen
- nog niet automatisch omwille van beperkte ruimte
- toggle om dicht te klappen pas zichtbaar vanaf er iets te zien is en meer dan 40px is
- toggle is voorlopig niet optioneel
- optioneel kan er een fixed header links bovenaan meegegeven worden (via ng-content)
- andere weergave als de scrollbar zichtbaar is (geen achtergrond + schaduw op linker paneel)