### PR TITLE
gebieden intekenen optioneel vertrekkend van een opgegeven geometrie

### DIFF
--- a/projects/ng-kaart/src/lib/classic/tekenen/kaart-teken.component.ts
+++ b/projects/ng-kaart/src/lib/classic/tekenen/kaart-teken.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, NgZone, OnInit, Output } from "@angular
 import { none, Option, some } from "fp-ts/lib/Option";
 import * as ol from "openlayers";
 import * as rx from "rxjs";
+import { identity } from "rxjs";
 import { distinctUntilChanged, filter, map, takeUntil } from "rxjs/operators";
 
 import { KaartComponentBase } from "../../kaart/kaart-component-base";
@@ -9,7 +10,7 @@ import { TekenSettings } from "../../kaart/kaart-elementen";
 import * as prt from "../../kaart/kaart-protocol";
 import * as ss from "../../kaart/stijl-selector";
 import { TekenenUiSelector } from "../../kaart/tekenen/kaart-teken-laag.component";
-import { ofType } from "../../util/operators";
+import { collect, ofType } from "../../util/operators";
 import { classicMsgSubscriptionCmdOperator, KaartClassicComponent } from "../kaart-classic.component";
 import { classicLogger } from "../log";
 import { KaartClassicMsg, TekenGeomAangepastMsg } from "../messages";
@@ -54,7 +55,7 @@ export class KaartTekenComponent extends KaartComponentBase implements OnInit {
     this.bindToLifeCycle(
       this.aanHetTekenen.pipe(
         distinctUntilChanged(),
-        filter(t => t !== null)
+        collect(identity)
       )
     ).subscribe(tekenen => {
       switch (tekenen) {
@@ -94,12 +95,7 @@ export class KaartTekenComponent extends KaartComponentBase implements OnInit {
         .pipe(
           takeUntil(this.stopTekenenSubj) // Unsubscribe bij stoppen met tekenen
         )
-    ).subscribe(
-      next => {
-        return;
-      },
-      err => classicLogger.error(err)
-    );
+    ).subscribe(next => classicLogger.error(next), err => classicLogger.error(err));
 
     // Zorg ervoor dat de getekende geom in de @Output terecht komen
     this.bindToLifeCycle(

--- a/projects/ng-kaart/src/lib/classic/tekenen/kaart-teken.component.ts
+++ b/projects/ng-kaart/src/lib/classic/tekenen/kaart-teken.component.ts
@@ -1,7 +1,8 @@
 import { Component, EventEmitter, Input, NgZone, OnInit, Output } from "@angular/core";
+import { none, Option, some } from "fp-ts/lib/Option";
 import * as ol from "openlayers";
 import * as rx from "rxjs";
-import { distinctUntilChanged, map, takeUntil } from "rxjs/operators";
+import { distinctUntilChanged, filter, map, takeUntil } from "rxjs/operators";
 
 import { KaartComponentBase } from "../../kaart/kaart-component-base";
 import { TekenSettings } from "../../kaart/kaart-elementen";
@@ -19,11 +20,13 @@ import { KaartClassicMsg, TekenGeomAangepastMsg } from "../messages";
 })
 export class KaartTekenComponent extends KaartComponentBase implements OnInit {
   private stopTekenenSubj: rx.Subject<void> = new rx.Subject<void>();
-  private aanHetTekenen = new rx.BehaviorSubject<boolean>(false);
+  private aanHetTekenen = new rx.BehaviorSubject<boolean | ol.geom.Geometry>(false);
+
   @Input()
-  set tekenen(teken: boolean) {
+  set tekenen(teken: boolean | ol.geom.Geometry) {
     this.aanHetTekenen.next(teken);
   }
+
   @Input()
   private geometryType: ol.geom.GeometryType = "LineString";
 
@@ -48,13 +51,29 @@ export class KaartTekenComponent extends KaartComponentBase implements OnInit {
 
   ngOnInit() {
     super.ngOnInit();
-    // TODO: dit kan allicht eleganter met een switchMap
-    this.bindToLifeCycle(this.aanHetTekenen.pipe(distinctUntilChanged())).subscribe(tekenen =>
-      tekenen ? this.startTekenen() : this.stopTekenen()
-    );
+    this.bindToLifeCycle(
+      this.aanHetTekenen.pipe(
+        distinctUntilChanged(),
+        filter(t => t !== null)
+      )
+    ).subscribe(tekenen => {
+      switch (tekenen) {
+        case true:
+          this.startTekenen(none);
+          break;
+        case false:
+          this.stopTekenen();
+          break;
+        default:
+          if (this.aanHetTekenen.getValue() === true) {
+            this.stopTekenen();
+          }
+          this.startTekenen(some(tekenen as ol.geom.Geometry));
+      }
+    });
   }
 
-  private startTekenen() {
+  private startTekenen(geometry: Option<ol.geom.Geometry>) {
     this.bindToLifeCycle(
       this.kaart.kaartClassicSubMsg$
         .lift(
@@ -63,6 +82,7 @@ export class KaartTekenComponent extends KaartComponentBase implements OnInit {
             prt.GeometryChangedSubscription(
               TekenSettings(
                 this.geometryType,
+                geometry,
                 ss.asStyleSelector(this.laagStyle),
                 ss.asStyleSelector(this.drawStyle),
                 this.meerdereGeometrieen
@@ -74,19 +94,25 @@ export class KaartTekenComponent extends KaartComponentBase implements OnInit {
         .pipe(
           takeUntil(this.stopTekenenSubj) // Unsubscribe bij stoppen met tekenen
         )
-    ).subscribe(err => classicLogger.error(err));
+    ).subscribe(
+      next => {
+        return;
+      },
+      err => classicLogger.error(err)
+    );
 
     // Zorg ervoor dat de getekende geom in de @Output terecht komen
     this.bindToLifeCycle(
       this.kaart.kaartClassicSubMsg$.pipe(
         ofType<TekenGeomAangepastMsg>("TekenGeomAangepast"), //
-        map(m => m.geom)
+        map(m => m.geom),
+        takeUntil(this.stopTekenenSubj)
       )
-    ).subscribe(geom => this.getekendeGeom.emit(geom));
+    ).subscribe(geom => this.getekendeGeom.emit(geom), err => classicLogger.error(err));
   }
 
   private stopTekenen() {
     this.stopTekenenSubj.next(); // zorg dat de unsubscribe gebeurt
-    this.stopTekenenSubj = new rx.Subject(); // en maak ons klaar voor de volgende ronde
+    this.stopTekenenSubj = new rx.Subject();
   }
 }

--- a/projects/ng-kaart/src/lib/kaart/kaart-elementen.ts
+++ b/projects/ng-kaart/src/lib/kaart/kaart-elementen.ts
@@ -120,6 +120,17 @@ export interface TekenSettings {
   readonly meerdereGeometrieen: boolean;
 }
 
+export interface StartTekenen {
+  type: "start";
+  settings: TekenSettings;
+}
+
+export interface StopTekenen {
+  type: "stop";
+}
+
+export type TekenenCommand = StartTekenen | StopTekenen;
+
 export interface TekenResultaat {
   readonly geometry: ol.geom.Geometry;
   readonly volgnummer: number;
@@ -179,6 +190,19 @@ export function TekenSettings(
     laagStyle: laagStyle,
     drawStyle: drawStyle,
     meerdereGeometrieen: meerdereGeometrieen
+  };
+}
+
+export function StartTekenen(settings: TekenSettings): StartTekenen {
+  return {
+    type: "start",
+    settings: settings
+  };
+}
+
+export function StopTekenen(): StopTekenen {
+  return {
+    type: "stop"
   };
 }
 

--- a/projects/ng-kaart/src/lib/kaart/kaart-elementen.ts
+++ b/projects/ng-kaart/src/lib/kaart/kaart-elementen.ts
@@ -114,6 +114,7 @@ export interface BlancoLaag {
 
 export interface TekenSettings {
   readonly geometryType: ol.geom.GeometryType;
+  readonly geometry: Option<ol.geom.Geometry>;
   readonly laagStyle: Option<StyleSelector>;
   readonly drawStyle: Option<StyleSelector>;
   readonly meerdereGeometrieen: boolean;
@@ -167,12 +168,14 @@ export const isZichtbaar: (_: number) => (_: ToegevoegdeLaag) => boolean = curre
 
 export function TekenSettings(
   geometryType: ol.geom.GeometryType,
+  geometry: Option<ol.geom.Geometry>,
   laagStyle: Option<StyleSelector>,
   drawStyle: Option<StyleSelector>,
   meerdereGeometrieen: boolean
 ): TekenSettings {
   return {
     geometryType: geometryType,
+    geometry: geometry,
     laagStyle: laagStyle,
     drawStyle: drawStyle,
     meerdereGeometrieen: meerdereGeometrieen

--- a/projects/ng-kaart/src/lib/kaart/meten/kaart-meten.component.ts
+++ b/projects/ng-kaart/src/lib/kaart/meten/kaart-meten.component.ts
@@ -114,7 +114,7 @@ export class KaartMetenComponent extends KaartModusComponent implements OnInit, 
       this.internalMessage$.lift(
         internalMsgSubscriptionCmdOperator(
           this.kaartComponent.internalCmdDispatcher,
-          prt.GeometryChangedSubscription(TekenSettings("Polygon", none, none, this.meerdereGeometrieen), tekenResultaatWrapper)
+          prt.GeometryChangedSubscription(TekenSettings("Polygon", none, none, none, this.meerdereGeometrieen), tekenResultaatWrapper)
         )
       )
     )

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from "@angular/core";
 import { FormsModule } from "@angular/forms";
+import { MatButtonToggleModule, MatSlideToggleModule } from "@angular/material";
 import { BrowserModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterModule } from "@angular/router";
-import { ClickOutsideModule } from "ng4-click-outside";
-
 import { ClassicModule, KaartModule, LagenkiezerModule, ZoekerModule } from "@wegenenverkeer/ng-kaart";
+import { ClickOutsideModule } from "ng4-click-outside";
 
 import { AppComponent, routes } from "./app.component";
 import { AvKaartInnerComponent } from "./av-kaart-inner.component";
@@ -30,6 +30,8 @@ import { TestSectieComponent } from "./test-sectie.component";
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
+    MatSlideToggleModule,
+    MatButtonToggleModule,
     KaartModule.withDefaults(),
     ClassicModule,
     FormsModule,

--- a/src/app/feature-demo.component.html
+++ b/src/app/feature-demo.component.html
@@ -53,6 +53,10 @@
       Zoeken
       <span class="material-icons" [ngClass]="{ 'niet-zichtbaar': !zoekenSectie.sectieZichtbaar }">visibility</span>
     </div>
+    <div (click)="tekenenSectie.toggleSectieZichtbaar();scrollTo('tekenen')" class="sub-titel">
+      Gebied intekenen
+      <span class="material-icons" [ngClass]="{ 'niet-zichtbaar': !tekenenSectie.sectieZichtbaar }">visibility</span>
+    </div>
   </div>
 
   <!-- applicaties -->
@@ -182,6 +186,7 @@
         <!-- kaart widgets-->
         <awv-kaart-streetview *ngIf="isOptieActief('streetview')"></awv-kaart-streetview>
         <awv-meet-knop [toonInfoBoodschap]="isOptieActief('metenToon')" [meerdereGeometrieen]="isOptieActief('metenMeerdere')" *ngIf="isOptieActief('meten')"></awv-meet-knop>
+        <awv-kaart-teken></awv-kaart-teken>
         <awv-kaart-zoomknoppen *ngIf="isOptieActief('zoomknoppen')"></awv-kaart-zoomknoppen>
         <awv-bevraag-kaart *ngIf="isOptieActief('bevraagkaart')"></awv-bevraag-kaart>
         <!-- kaartinfo -->
@@ -389,6 +394,27 @@
         </awv-kaart-classic>
       </div>
       </awv-test-sectie>
+
+      <awv-test-sectie sectieId="tekenen" sectieTitel="Gebied intekenen" [subSectie]="true" #tekenenSectie
+                       [sectieZichtbaar]="voorbeeldenSectie.sectieZichtbaar && tekenenSectie.sectieZichtbaar">
+        <div>
+          <mat-button-toggle-group [(ngModel)]="geometryType" [disabled]="tekenenActief">
+            <mat-button-toggle value="Polygon">Polygon</mat-button-toggle>
+            <mat-button-toggle value="LineString">LineString</mat-button-toggle>
+          </mat-button-toggle-group>
+          <mat-slide-toggle (change)="toggleTekenen()" style="margin-left: 8px;">Tekenen</mat-slide-toggle>
+        </div>
+
+        <div *ngIf="tekenenSectie.sectieZichtbaar" [@enterAnimation]>
+          <awv-kaart-classic [naam]="'tekenen'" [breedte]="1200" [hoogte]="600" [zoom]="6" [middelpunt]="installatieCoordinaat">
+            <awv-kaart-tilecache-laag [titel]="'Dienstkaart grijs'" [laagNaam]="'dienstkaart-grijs'"></awv-kaart-tilecache-laag>
+            <awv-kaart-schaal></awv-kaart-schaal>
+            <awv-kaart-teken [geometryType]="geometryType" [tekenen]="tekenenActief" (getekendeGeom)="geomGetekend($event)"></awv-kaart-teken>
+            <awv-kaart-knop-volledig-scherm></awv-kaart-knop-volledig-scherm>
+          </awv-kaart-classic>
+        </div>
+      </awv-test-sectie>
+
     </div>
 
   </awv-test-sectie>

--- a/src/app/feature-demo.component.ts
+++ b/src/app/feature-demo.component.ts
@@ -388,11 +388,7 @@ export class FeatureDemoComponent {
     zoekerMetPrioriteiten(new DummyZoeker("dummy3"), 3, 3)
   ];
 
-  constructor() {
-    kaartLogger.setLevel("DEBUG");
-    classicLogger.setLevel("DEBUG");
-    this.addIcon();
-  }
+  private geometryType = "Polygon";
 
   private addIcon() {
     if (this.installaties.length > 20) {
@@ -449,11 +445,12 @@ export class FeatureDemoComponent {
     this.getekendeGeom = none;
   }
 
-  get tekenGeomLength() {
-    return this.getekendeGeom
-      .filter(g => g.getType() === "LineString" || g.getType() === "Polygon")
-      .map(g => Math.round((ol.Sphere.getLength(g) / 1000) * 100) / 100 + "km")
-      .getOrElse("(leeg)");
+  toggleTekenen() {
+    if (this.isTekenenActief()) {
+      this.stopTekenen();
+    } else {
+      this.startTekenen();
+    }
   }
 
   geomGetekend(geom: ol.geom.Geometry) {


### PR DESCRIPTION
Een uitbreiding van de `KaartTekenLaagComponent` en de `KaartTekenComponent` componenten,
Laat toe om:

- een gebied op te geven bij tonen van kaart dat dan nog kan gemanipuleerd worden
- een gebied via een andere manier dan de kaart te manipuleren, bv buffering via +/- knoppen
- ...

