### PR TITLE
Update deprecated warning of Workbox v3 -> v4

### DIFF
--- a/src/workbox/index.js
+++ b/src/workbox/index.js
@@ -10,7 +10,7 @@ self.addEventListener('message', event => {
     case 'REGISTER_ROUTE':
       const { requestPattern, cacheName } = payload;
       info(`Routing ${requestPattern} to cache ${cacheName}`);
-      const handler = strategies.cacheFirst({
+      const handler = new strategies.CacheFirst({
           cacheName: cacheName,
           plugins: typeof ngKaartRoutePlugins !== 'undefined' ? ngKaartRoutePlugins : []
       });


### PR DESCRIPTION
Fixes
```
The 'workbox.strategies.cacheFirst()' function has been deprecated and will be removed in a future version of Workbox.
Please use 'new workbox.strategies.CacheFirst()' instead.
```