### PR TITLE
controle op lege set "aanwezigeElementen"

### DIFF
--- a/projects/ng-kaart/src/lib/kaart/kaart.component.html
+++ b/projects/ng-kaart/src/lib/kaart/kaart.component.html
@@ -30,35 +30,37 @@
     <awv-kaart-teken-laag *ngIf="aanwezigeElementen.has('Kaarttekenen')"></awv-kaart-teken-laag>
     <awv-kaart-multi-teken-laag *ngIf="aanwezigeElementen.has('MultiKaarttekenen')"></awv-kaart-multi-teken-laag>
   </div>
-  <div class="overlay-container" *ngIf="aanwezigeElementen$ | async as aanwezigeElementen">
-    <div id="overlay">
-      <div class="kaart-rechts-onderaan">
-        <div class="kaart-interacties">
-          <awv-kaart-achtergrond-selector class="kaart-achtergrond-selector"
-            *ngIf="aanwezigeElementen.has('Achtergrondkeuze')"></awv-kaart-achtergrond-selector>
-          <div class="kaart-controls">
-            <awv-kaart-rotatie></awv-kaart-rotatie>
-            <awv-kaart-open-street-view *ngIf="aanwezigeElementen.has('Streetview')"></awv-kaart-open-street-view>
-            <awv-kaart-meten *ngIf="aanwezigeElementen.has('Meten')"></awv-kaart-meten>
-            <awv-kaart-multi-meten *ngIf="aanwezigeElementen.has('MultiMeten')"></awv-kaart-multi-meten>
-            <awv-kaart-mijn-locatie *ngIf="aanwezigeElementen.has('Mijnlocatie')"></awv-kaart-mijn-locatie>
-            <awv-kaart-mijn-mobiele-locatie *ngIf="aanwezigeElementen.has('MijnMobielelocatie')">
-            </awv-kaart-mijn-mobiele-locatie>
-            <awv-kaart-zoom *ngIf="aanwezigeElementen.has('Zoomknoppen')"></awv-kaart-zoom>
-            <awv-kaart-bevragen *ngIf="aanwezigeElementen.has('Bevraagkaart')"></awv-kaart-bevragen>
-            <awv-identify *ngIf="aanwezigeElementen.has('Identify')"></awv-identify>
-            <awv-markeer-kaartklik *ngIf="aanwezigeElementen.has('MarkeerKaartklik')"></awv-markeer-kaartklik>
+  <ng-container *ngIf="aanwezigeElementen$ | async as aanwezigeElementen">
+    <div class="overlay-container" *ngIf="aanwezigeElementen.size > 0">
+      <div id="overlay">
+        <div class="kaart-rechts-onderaan">
+          <div class="kaart-interacties">
+            <awv-kaart-achtergrond-selector class="kaart-achtergrond-selector"
+              *ngIf="aanwezigeElementen.has('Achtergrondkeuze')"></awv-kaart-achtergrond-selector>
+            <div class="kaart-controls">
+              <awv-kaart-rotatie></awv-kaart-rotatie>
+              <awv-kaart-open-street-view *ngIf="aanwezigeElementen.has('Streetview')"></awv-kaart-open-street-view>
+              <awv-kaart-meten *ngIf="aanwezigeElementen.has('Meten')"></awv-kaart-meten>
+              <awv-kaart-multi-meten *ngIf="aanwezigeElementen.has('MultiMeten')"></awv-kaart-multi-meten>
+              <awv-kaart-mijn-locatie *ngIf="aanwezigeElementen.has('Mijnlocatie')"></awv-kaart-mijn-locatie>
+              <awv-kaart-mijn-mobiele-locatie *ngIf="aanwezigeElementen.has('MijnMobielelocatie')">
+              </awv-kaart-mijn-mobiele-locatie>
+              <awv-kaart-zoom *ngIf="aanwezigeElementen.has('Zoomknoppen')"></awv-kaart-zoom>
+              <awv-kaart-bevragen *ngIf="aanwezigeElementen.has('Bevraagkaart')"></awv-kaart-bevragen>
+              <awv-identify *ngIf="aanwezigeElementen.has('Identify')"></awv-identify>
+              <awv-markeer-kaartklik *ngIf="aanwezigeElementen.has('MarkeerKaartklik')"></awv-markeer-kaartklik>
+            </div>
+          </div>
+          <div class="kaart-footer-info" [ngClass]="{ 'tabel-geopend': (tabelGeopend$ | async)}">
+            <awv-copyright *ngIf="aanwezigeElementen.has('Copyright')"></awv-copyright>
+            <awv-voorwaarden *ngIf="aanwezigeElementen.has('Voorwaarden')"></awv-voorwaarden>
+            <awv-schaal *ngIf="aanwezigeElementen.has('Schaal')"></awv-schaal>
           </div>
         </div>
-        <div class="kaart-footer-info" [ngClass]="{ 'tabel-geopend': (tabelGeopend$ | async)}">
-          <awv-copyright *ngIf="aanwezigeElementen.has('Copyright')"></awv-copyright>
-          <awv-voorwaarden *ngIf="aanwezigeElementen.has('Voorwaarden')"></awv-voorwaarden>
-          <awv-schaal *ngIf="aanwezigeElementen.has('Schaal')"></awv-schaal>
-        </div>
       </div>
+      <ng-container>
+        <awv-feature-tabel-inklap *ngIf="aanwezigeElementen.has('FeatureTabel')"></awv-feature-tabel-inklap>
+      </ng-container>
     </div>
-    <ng-container>
-      <awv-feature-tabel-inklap *ngIf="aanwezigeElementen.has('FeatureTabel')"></awv-feature-tabel-inklap>
-    </ng-container>
-  </div>
+  </ng-container>
 </div>

--- a/projects/ng-kaart/src/lib/kaart/kaart.component.html
+++ b/projects/ng-kaart/src/lib/kaart/kaart.component.html
@@ -2,35 +2,35 @@
   <div id="kaart-container" style="height: 100%; width: 100%;">
     <div class="kaart" #map style="height: 100%; width: 100%;"></div>
   </div>
-  <div class="full-height-overlay" *ngIf="aanwezigeElementen$ | async as aanwezigeElementen" [ngClass]="{ 'kaart-links-zichtbaar': kaartLinksZichtbaar,
-  'kaart-links-niet-zichtbaar': !kaartLinksZichtbaar,
-  'kaart-links-scrollbar-zichtbaar': kaartLinksScrollbarZichtbaar,
-  'kaart-links-scrollbar-niet-zichtbaar': !kaartLinksScrollbarZichtbaar }">
-    <awv-ladend></awv-ladend>
-    <button #kaartLinksZichtbaarToggleKnop mat-icon-button *ngIf="kaartLinksToggleZichtbaar"
-      class="kaart-links-zichtbaar-toggle-knop" (click)="toggleKaartLinks()"
-      [matTooltip]="kaartLinksZichtbaar ? 'Verberg paneel' : 'Toon paneel'" matTooltipPosition="right">
-      <mat-icon *ngIf="kaartLinksZichtbaar">chevron_left</mat-icon>
-      <mat-icon *ngIf="!kaartLinksZichtbaar">chevron_right</mat-icon>
-    </button>
-    <div #kaartFixedLinksBoven class="kaart-fixed-links-boven">
-      <ng-content select=".kaart-fixed-links-boven"></ng-content>
-    </div>
-    <div #kaartLinks class="kaart-links">
-      <awv-zoeker *ngIf="aanwezigeElementen.has('Zoeker')"></awv-zoeker>
-      <awv-lagenkiezer *ngIf="aanwezigeElementen.has('Lagenkiezer')"></awv-lagenkiezer>
-      <awv-laagstijleditor></awv-laagstijleditor>
-      <awv-transparantieeditor></awv-transparantieeditor>
-      <awv-kaart-info-boodschappen></awv-kaart-info-boodschappen>
-      <ng-content select=".kaart-links"></ng-content>
-    </div>
-    <div class="kaart-centraal">
-      <awv-filter-editor></awv-filter-editor>
-    </div>
-    <awv-kaart-teken-laag *ngIf="aanwezigeElementen.has('Kaarttekenen')"></awv-kaart-teken-laag>
-    <awv-kaart-multi-teken-laag *ngIf="aanwezigeElementen.has('MultiKaarttekenen')"></awv-kaart-multi-teken-laag>
-  </div>
   <ng-container *ngIf="aanwezigeElementen$ | async as aanwezigeElementen">
+    <div class="full-height-overlay" *ngIf="aanwezigeElementen$ | async as aanwezigeElementen" [ngClass]="{ 'kaart-links-zichtbaar': kaartLinksZichtbaar,
+    'kaart-links-niet-zichtbaar': !kaartLinksZichtbaar,
+    'kaart-links-scrollbar-zichtbaar': kaartLinksScrollbarZichtbaar,
+    'kaart-links-scrollbar-niet-zichtbaar': !kaartLinksScrollbarZichtbaar }">
+      <awv-ladend></awv-ladend>
+      <button #kaartLinksZichtbaarToggleKnop mat-icon-button *ngIf="kaartLinksToggleZichtbaar"
+        class="kaart-links-zichtbaar-toggle-knop" (click)="toggleKaartLinks()"
+        [matTooltip]="kaartLinksZichtbaar ? 'Verberg paneel' : 'Toon paneel'" matTooltipPosition="right">
+        <mat-icon *ngIf="kaartLinksZichtbaar">chevron_left</mat-icon>
+        <mat-icon *ngIf="!kaartLinksZichtbaar">chevron_right</mat-icon>
+      </button>
+      <div #kaartFixedLinksBoven class="kaart-fixed-links-boven">
+        <ng-content select=".kaart-fixed-links-boven"></ng-content>
+      </div>
+      <div #kaartLinks class="kaart-links">
+        <awv-zoeker *ngIf="aanwezigeElementen.has('Zoeker')"></awv-zoeker>
+        <awv-lagenkiezer *ngIf="aanwezigeElementen.has('Lagenkiezer')"></awv-lagenkiezer>
+        <awv-laagstijleditor></awv-laagstijleditor>
+        <awv-transparantieeditor></awv-transparantieeditor>
+        <awv-kaart-info-boodschappen></awv-kaart-info-boodschappen>
+        <ng-content select=".kaart-links"></ng-content>
+      </div>
+      <div class="kaart-centraal">
+        <awv-filter-editor></awv-filter-editor>
+      </div>
+      <awv-kaart-teken-laag *ngIf="aanwezigeElementen.has('Kaarttekenen')"></awv-kaart-teken-laag>
+      <awv-kaart-multi-teken-laag *ngIf="aanwezigeElementen.has('MultiKaarttekenen')"></awv-kaart-multi-teken-laag>
+    </div>
     <div class="overlay-container" *ngIf="aanwezigeElementen.size > 0">
       <div id="overlay">
         <div class="kaart-rechts-onderaan">


### PR DESCRIPTION
NIET MERGEN, HEEFT BUGS

Deze PR geeft het probleem aan. Zelfs met een lege set worden bepaalde elementen getoond die niet getoond zouden mogen worden. Het zou voor een integrerende applicatie mogelijk moeten zijn om alle UI elementen die native zijn aan ng-kaart te onderdrukken.