### PR TITLE
Ux 268 mob friendly buttons achtergrond en huidige locatie

### DIFF
--- a/projects/ng-kaart/src/lib/css/kaart.component-common.scss
+++ b/projects/ng-kaart/src/lib/css/kaart.component-common.scss
@@ -24,7 +24,7 @@ $tablet-breakpoint: 720px;
 }
 
 // De default kaart-widget componenten zijn te klein om gemakkelijk aanklikbaar te zijn op mobile dus verbergen we die
-.kaart-interacties.mobile-friendly .kaart-controls .kaart-widget {
+.kaart-interacties.handset-portrait .kaart-controls .kaart-widget {
   display: none;
 }
 

--- a/projects/ng-kaart/src/lib/css/kaart.component-common.scss
+++ b/projects/ng-kaart/src/lib/css/kaart.component-common.scss
@@ -23,6 +23,11 @@ $tablet-breakpoint: 720px;
   border-radius: 2px;
 }
 
+// De default kaart-widget componenten zijn te klein om gemakkelijk aanklikbaar te zijn op mobile dus verbergen we die
+.kaart-interacties.mobile-friendly .kaart-controls .kaart-widget {
+  display: none;
+}
+
 .divider {
   flex-grow: 1;
   margin-left: auto;

--- a/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.html
+++ b/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.html
@@ -19,10 +19,10 @@
     </div>
   </div>
 
-  <div [ngClass]="(mobileFriendly$ | async) && handsetPortrait ? 'achtergrond-selector__mobile-friendly' : 'kaart-widget achtergrond-selector__mobile'"
+  <div [ngClass]="handsetPortrait ? 'achtergrond-selector__handset-portrait' : 'kaart-widget achtergrond-selector__mobile'"
        [class.achtergrond-selector__mobile--actief]="DisplayMode.SELECTING === displayMode">
     <button mat-button
-            [ngClass]="(mobileFriendly$ | async) && handsetPortrait ? 'mat-fab' : 'mat-icon-button'"
+            [ngClass]="handsetPortrait ? 'mat-fab' : 'mat-icon-button'"
             color=""
             (click)="open()">
       <mat-icon aria-label="Achtergrondkaart selecteren">layers</mat-icon>

--- a/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.html
+++ b/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.html
@@ -19,9 +19,11 @@
     </div>
   </div>
 
-  <div class="kaart-widget achtergrond-selector__mobile"
+  <div [ngClass]="(mobileFriendly$ | async) && handsetPortrait ? 'achtergrond-selector__mobile-friendly' : 'kaart-widget achtergrond-selector__mobile'"
        [class.achtergrond-selector__mobile--actief]="DisplayMode.SELECTING === displayMode">
-    <button mat-icon-button
+    <button mat-button
+            [ngClass]="(mobileFriendly$ | async) && handsetPortrait ? 'mat-fab' : 'mat-icon-button'"
+            color=""
             (click)="open()">
       <mat-icon aria-label="Achtergrondkaart selecteren">layers</mat-icon>
     </button>

--- a/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.html
+++ b/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.html
@@ -23,7 +23,7 @@
        [class.achtergrond-selector__mobile--actief]="DisplayMode.SELECTING === displayMode">
     <button mat-icon-button
             (click)="open()">
-      <mat-icon aria-label="Meten van lengte en oppervlakte">layers</mat-icon>
+      <mat-icon aria-label="Achtergrondkaart selecteren">layers</mat-icon>
     </button>
   </div>
 </div>

--- a/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.scss
+++ b/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.scss
@@ -67,7 +67,7 @@ $gridunit: 8px;
     }
 
     @media screen and (max-width: $mobile-breakpoint-max) {
-      pointer-events: all;
+      pointer-events: initial;
       white-space: nowrap;
       overflow: scroll;
       width: 100%;
@@ -97,6 +97,15 @@ $gridunit: 8px;
     &--actief {
       color: $kaart-icon-button-active;
     }
+
+    @media screen and (min-width: $tablet-breakpoint) {
+      display: none;
+    }
+  }
+
+  &__mobile-friendly {
+    pointer-events: auto;
+    margin: 0 16px 8px 0;
 
     @media screen and (min-width: $tablet-breakpoint) {
       display: none;

--- a/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.scss
+++ b/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.scss
@@ -103,7 +103,7 @@ $gridunit: 8px;
     }
   }
 
-  &__mobile-friendly {
+  &__handset-portrait {
     pointer-events: auto;
     margin: 0 16px 8px 0;
 

--- a/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.ts
+++ b/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.ts
@@ -68,7 +68,6 @@ export class KaartAchtergrondSelectorComponent extends KaartChildComponentBase i
   public readonly DisplayMode = DisplayMode;
   public displayMode: DisplayMode = DisplayMode.SHOWING_STATUS;
   public achtergrondTitel = "";
-  mobileFriendly$: rx.Observable<boolean> = rx.of(true); // TODO: moet configureerbaar gemaakt worden!!!
   readonly onMobileDevice = mobile;
   handsetPortrait = false;
 

--- a/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.ts
+++ b/projects/ng-kaart/src/lib/kaart/achtergrond-selector/kaart-achtergrond-selector.component.ts
@@ -1,4 +1,5 @@
 import { animate, state, style, transition, trigger } from "@angular/animations";
+import { BreakpointObserver, Breakpoints } from "@angular/cdk/layout";
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, NgZone, OnInit } from "@angular/core";
 import * as rx from "rxjs";
 import { map, switchMap, takeUntil } from "rxjs/operators";
@@ -6,6 +7,7 @@ import { map, switchMap, takeUntil } from "rxjs/operators";
 import { ofType } from "../../util/operators";
 
 import { KaartChildComponentBase } from "../kaart-child-component-base";
+import { mobile } from "../kaart-config";
 import { AchtergrondLaag, ToegevoegdeLaag } from "../kaart-elementen";
 import { AchtergrondtitelGezetMsg, achtergrondtitelGezetWrapper, KaartInternalMsg, kaartLogOnlyWrapper } from "../kaart-internal-messages";
 import * as prt from "../kaart-protocol";
@@ -66,10 +68,18 @@ export class KaartAchtergrondSelectorComponent extends KaartChildComponentBase i
   public readonly DisplayMode = DisplayMode;
   public displayMode: DisplayMode = DisplayMode.SHOWING_STATUS;
   public achtergrondTitel = "";
+  mobileFriendly$: rx.Observable<boolean> = rx.of(true); // TODO: moet configureerbaar gemaakt worden!!!
+  readonly onMobileDevice = mobile;
+  handsetPortrait = false;
 
   readonly backgroundTiles$: rx.Observable<Array<ToegevoegdeLaag>> = rx.EMPTY;
 
-  constructor(private readonly cdr: ChangeDetectorRef, kaartComponent: KaartComponent, zone: NgZone) {
+  constructor(
+    private readonly cdr: ChangeDetectorRef,
+    kaartComponent: KaartComponent,
+    zone: NgZone,
+    breakpointObserver: BreakpointObserver
+  ) {
     super(kaartComponent, zone);
 
     this.backgroundTiles$ = this.initialising$.pipe(switchMap(() => this.modelChanges.lagenOpGroep.Achtergrond.pipe(map(lgn => lgn))));
@@ -88,6 +98,12 @@ export class KaartAchtergrondSelectorComponent extends KaartChildComponentBase i
         this.achtergrondTitel = titel;
         this.cdr.detectChanges();
       });
+
+    breakpointObserver.observe([Breakpoints.HandsetPortrait]).subscribe(result => {
+      // Gebruik van built-in breakpoints uit de Material Design spec: https://material.angular.io/cdk/layout/overview
+      this.handsetPortrait = result.matches && this.onMobileDevice;
+      this.cdr.detectChanges();
+    });
   }
 
   protected kaartSubscriptions(): prt.Subscription<KaartInternalMsg>[] {

--- a/projects/ng-kaart/src/lib/kaart/kaart.component.html
+++ b/projects/ng-kaart/src/lib/kaart/kaart.component.html
@@ -33,7 +33,7 @@
   <div class="overlay-container" *ngIf="aanwezigeElementen$ | async as aanwezigeElementen">
     <div id="overlay">
       <div class="kaart-rechts-onderaan">
-        <div class="kaart-interacties" [ngClass]="{ 'mobile-friendly': (mobileFriendly$ | async) && handsetPortrait }">
+        <div class="kaart-interacties" [ngClass]="{ 'handset-portrait': handsetPortrait }">
           <awv-kaart-achtergrond-selector class="kaart-achtergrond-selector"
             *ngIf="aanwezigeElementen.has('Achtergrondkeuze')"></awv-kaart-achtergrond-selector>
           <div class="kaart-controls">

--- a/projects/ng-kaart/src/lib/kaart/kaart.component.html
+++ b/projects/ng-kaart/src/lib/kaart/kaart.component.html
@@ -33,7 +33,7 @@
   <div class="overlay-container" *ngIf="aanwezigeElementen$ | async as aanwezigeElementen">
     <div id="overlay">
       <div class="kaart-rechts-onderaan">
-        <div class="kaart-interacties">
+        <div class="kaart-interacties" [ngClass]="{ 'mobile-friendly': (mobileFriendly$ | async) && handsetPortrait }">
           <awv-kaart-achtergrond-selector class="kaart-achtergrond-selector"
             *ngIf="aanwezigeElementen.has('Achtergrondkeuze')"></awv-kaart-achtergrond-selector>
           <div class="kaart-controls">

--- a/projects/ng-kaart/src/lib/kaart/kaart.component.scss
+++ b/projects/ng-kaart/src/lib/kaart/kaart.component.scss
@@ -221,7 +221,7 @@ awv-kaart-info-boodschappen {
     align-items: flex-end;
     justify-content: flex-end;
 
-    &.mobile-friendly {
+    &.handset-portrait {
       flex-direction: column-reverse;
     }
   }

--- a/projects/ng-kaart/src/lib/kaart/kaart.component.scss
+++ b/projects/ng-kaart/src/lib/kaart/kaart.component.scss
@@ -220,6 +220,10 @@ awv-kaart-info-boodschappen {
     display: flex;
     align-items: flex-end;
     justify-content: flex-end;
+
+    &.mobile-friendly {
+      flex-direction: column-reverse;
+    }
   }
 
   .kaart-achtergrond-selector {

--- a/projects/ng-kaart/src/lib/kaart/kaart.component.ts
+++ b/projects/ng-kaart/src/lib/kaart/kaart.component.ts
@@ -61,7 +61,6 @@ export class KaartComponent extends KaartComponentBase {
   private readonly resizeCommand$: rx.Observable<prt.VeranderViewportCmd>;
   readonly containerResize$: rx.Observable<ol.Size>;
   tabelGeopend$: rx.Observable<boolean>;
-  mobileFriendly$: rx.Observable<boolean> = rx.of(true); // TODO: moet configureerbaar gemaakt worden!!!
   readonly onMobileDevice = mobile;
   handsetPortrait = false;
 

--- a/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.html
+++ b/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.html
@@ -1,5 +1,8 @@
-<div *ngIf="enabled$ | async" class="kaart-widget mijn-locatie">
-  <button #locateBtn mat-icon-button *ngIf="currentState$ | async as currentState" (click)="click()"
+<div *ngIf="enabled$ | async"
+     [ngClass]="(mobileFriendly$ | async) && handsetPortrait ? 'mijn-locatie__mobile-friendly' : 'kaart-widget mijn-locatie'">
+  <button #locateBtn mat-button *ngIf="currentState$ | async as currentState" (click)="click()"
+    [ngClass]="(mobileFriendly$ | async) && handsetPortrait ? 'mat-fab' : 'mat-icon-button'"
+    color=""
     [disabled]="currentState === 'TrackingDisabled'"
     [matTooltip]="isTrackingActief(currentState) ? 'Stop locatie tracking' : 'Start locatie tracking'"
     matTooltipPosition="left">

--- a/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.html
+++ b/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="enabled$ | async"
-     [ngClass]="(mobileFriendly$ | async) && handsetPortrait ? 'mijn-locatie__mobile-friendly' : 'kaart-widget mijn-locatie'">
+     [ngClass]="handsetPortrait ? 'mijn-locatie__handset-portrait' : 'kaart-widget mijn-locatie'">
   <button #locateBtn mat-button *ngIf="currentState$ | async as currentState" (click)="click()"
-    [ngClass]="(mobileFriendly$ | async) && handsetPortrait ? 'mat-fab' : 'mat-icon-button'"
+    [ngClass]="handsetPortrait ? 'mat-fab' : 'mat-icon-button'"
     color=""
     [disabled]="currentState === 'TrackingDisabled'"
     [matTooltip]="isTrackingActief(currentState) ? 'Stop locatie tracking' : 'Start locatie tracking'"

--- a/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.scss
+++ b/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.scss
@@ -10,12 +10,12 @@
     line-height: 32px;
   }
 
-  &__mobile-friendly {
+  &__handset-portrait {
     pointer-events: auto;
     margin: 0 16px 16px 0;
   }
 
-  .actief, &__mobile-friendly .actief {
+  .actief, &__handset-portrait .actief {
     color: $awv-primary-3;
   }
 }

--- a/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.scss
+++ b/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.scss
@@ -10,7 +10,12 @@
     line-height: 32px;
   }
 
-  .actief {
+  &__mobile-friendly {
+    pointer-events: auto;
+    margin: 0 16px 16px 0;
+  }
+
+  .actief, &__mobile-friendly .actief {
     color: $awv-primary-3;
   }
 }

--- a/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.ts
+++ b/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.ts
@@ -1,3 +1,4 @@
+import { BreakpointObserver, Breakpoints } from "@angular/cdk/layout";
 import { AfterViewInit, Component, NgZone, OnInit, QueryList, ViewChildren } from "@angular/core";
 import { MatButton } from "@angular/material";
 import { Function1, Predicate } from "fp-ts/lib/function";
@@ -23,6 +24,7 @@ import {
 import { Transparantie } from "../../transparantieeditor/transparantie";
 import * as ol from "../../util/openlayers-compat";
 import { catOptions } from "../../util/operators";
+import { mobile } from "../kaart-config";
 import * as ke from "../kaart-elementen";
 import { kaartLogOnlyWrapper } from "../kaart-internal-messages";
 import { KaartModusComponent } from "../kaart-modus-component";
@@ -254,8 +256,12 @@ const locatieStijlFunctie: Function1<TrackingInfo, ol.style.StyleFunction> = inf
   styleUrls: ["./kaart-mijn-locatie.component.scss"]
 })
 export class KaartMijnLocatieComponent extends KaartModusComponent implements OnInit, AfterViewInit {
-  constructor(zone: NgZone, private readonly parent: KaartComponent) {
+  constructor(zone: NgZone, private readonly parent: KaartComponent, breakpointObserver: BreakpointObserver) {
     super(parent, zone);
+    breakpointObserver.observe([Breakpoints.HandsetPortrait]).subscribe(result => {
+      // Gebruik van built-in breakpoints uit de Material Design spec: https://material.angular.io/cdk/layout/overview
+      this.handsetPortrait = result.matches && this.onMobileDevice;
+    });
   }
 
   private viewinstellingen$: rx.Observable<Viewinstellingen> = rx.EMPTY;
@@ -267,6 +273,10 @@ export class KaartMijnLocatieComponent extends KaartModusComponent implements On
 
   currentState$: rx.Observable<State> = rx.of("TrackingDisabled" as State);
   enabled$: rx.Observable<boolean> = rx.of(true);
+
+  mobileFriendly$: rx.Observable<boolean> = rx.of(true); // TODO: moet configureerbaar gemaakt worden!!!
+  readonly onMobileDevice = mobile;
+  handsetPortrait = false;
 
   @ViewChildren("locateBtn")
   locateBtnQry: QueryList<MatButton>;

--- a/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.ts
+++ b/projects/ng-kaart/src/lib/kaart/mijn-locatie/kaart-mijn-locatie.component.ts
@@ -274,7 +274,6 @@ export class KaartMijnLocatieComponent extends KaartModusComponent implements On
   currentState$: rx.Observable<State> = rx.of("TrackingDisabled" as State);
   enabled$: rx.Observable<boolean> = rx.of(true);
 
-  mobileFriendly$: rx.Observable<boolean> = rx.of(true); // TODO: moet configureerbaar gemaakt worden!!!
   readonly onMobileDevice = mobile;
   handsetPortrait = false;
 

--- a/src/app/feature-demo.component.ts
+++ b/src/app/feature-demo.component.ts
@@ -402,7 +402,6 @@ export class FeatureDemoComponent {
     meten: { value: true, label: "Meten" },
     mijnlocatie: { value: true, label: "Mijn huidige locatie" },
     zoomknoppen: { value: true, label: "Zoomknoppen" },
-    mobileFriendlyModus: { value: false, label: "Mobile Friendly Modus" },
 
     // --- Meten opties
     optieDivider3a: { divider: true, value: true, label: "Meten opties (teken modus op en afzetten na veranderingen)" },

--- a/src/app/feature-demo.component.ts
+++ b/src/app/feature-demo.component.ts
@@ -402,6 +402,7 @@ export class FeatureDemoComponent {
     meten: { value: true, label: "Meten" },
     mijnlocatie: { value: true, label: "Mijn huidige locatie" },
     zoomknoppen: { value: true, label: "Zoomknoppen" },
+    mobileFriendlyModus: { value: false, label: "Mobile Friendly Modus" },
 
     // --- Meten opties
     optieDivider3a: { divider: true, value: true, label: "Meten opties (teken modus op en afzetten na veranderingen)" },


### PR DESCRIPTION
### Mobile friendly modus
Knoppen rechts onderaan worden beperkt tot "mijn-locatie" en "achtergrond-selectie" en worden iets groter door via fab-knoppen te werken naar analogie van google maps. Deze visualisatie is enkel actief op smartpone in portrait mode.
Deze feature is om Movin nog gebruiksvriendelijker te maken op smartphone.

<img width="82" alt="Screenshot 2020-04-17 16 53 26" src="https://user-images.githubusercontent.com/220135/79834186-ebafc500-83ac-11ea-806d-8f2e6df6e1a4.png">
